### PR TITLE
Replacing lein-sub with lein-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ A thin wrapper around Finagle & Twitter Future.
 This library assumes you are familiar with Finagle.
 If not, check out its [docs](https://twitter.github.io/finagle/guide/).
 
+## Testing
+
+First you need to run:
+```
+lein modules install
+```
+
+And then:
+```
+lein modules midje
+```
+

--- a/core/project.clj
+++ b/core/project.clj
@@ -1,11 +1,12 @@
-(defproject finagle-clojure/core "0.8.0-NUBANK"
+(defproject finagle-clojure/core "0.8.0-SNAPSHOT"
   :description "A light wrapper around Finagle & Twitter Util for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
   :scm {:name "git" :url "http://github.com/nubank/finagle-clojure" :dir ".."}
   :plugins [[s3-wagon-private "1.3.1"]
-            [lein-midje "3.2"]]
+            [lein-midje "3.2"]
+            [lein-modules "0.3.11"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]
                                   [criterium "0.4.4"]]}}

--- a/http/project.clj
+++ b/http/project.clj
@@ -1,15 +1,16 @@
-(defproject finagle-clojure/http "0.8.0-NUBANK"
+(defproject finagle-clojure/http "0.8.0-SNAPSHOT"
   :description "A light wrapper around Finagle HTTP for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
   :scm {:name "git" :url "https://github.com/nubank/finagle-clojure"}
   :plugins [[s3-wagon-private "1.3.1"]
-            [lein-midje "3.2"]]
+            [lein-midje "3.2"]
+            [lein-modules "0.3.11"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]]}}
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
-  :dependencies [[finagle-clojure/core "0.8.0-NUBANK"]
+  :dependencies [[finagle-clojure/core "0.8.0-SNAPSHOT"]
                  [com.twitter/finagle-http_2.11 "19.12.0"]
                  [com.twitter/finagle-stats_2.11 "19.12.0"]])

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -5,7 +5,8 @@
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :scm {:name "git" :url "https://github.com/finagle/finagle-clojure"}
   :min-lein-version "2.0.0"
-  :plugins [[s3-wagon-private "1.3.1"]]
+  :plugins [[s3-wagon-private "1.3.1"]
+            [lein-modules "0.3.11"]]
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]
                  ["sonatype" "https://oss.sonatype.org/content/groups/public/"]
                  ["twitter" {:url "https://maven.twttr.com/" :checksum :warn}]]

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,32 @@
-(defproject finagle-clojure "0.8.0-NUBANK"
+(defproject finagle-clojure "0.8.0-SNAPSHOT"
   :description "A light wrapper around Finagle for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
             :url  "https://www.apache.org/licenses/LICENSE-2.0"}
   :scm {:name "git" :url "https://github.com/nubank/finagle-clojure"}
-  :dependencies [[finagle-clojure/core "0.8.0-NUBANK"]
-                 [finagle-clojure/thrift "0.8.0-NUBANK"]
-                 [finagle-clojure/http "0.8.0-NUBANK"]]
-  :plugins [[lein-sub "0.3.0"]
-            [codox "0.8.10"]
-            [lein-midje "3.2"]]
-  :sub ["core" "thrift" "http"]
+  :plugins [[lein-modules "0.3.11"]
+            [codox "0.8.10"]]
+  :profiles {:inherited  {:repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]
+                                        ["sonatype" "https://oss.sonatype.org/content/groups/public/"]
+                                        ["twitter" {:url "https://maven.twttr.com/" :checksum :warn}]]
+                          :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
+                          :aliases      {"bump-release"  ["do" ["change" "version" "leiningen.release/bump-version" "release"]
+                                                               ["change" "version" "str" "\"-NUBANK\""]]}}
+             :unit       {:modules {:dirs ^:replace ["core" "thrift" "http"]}}
+             :ci         {:release-tasks [["vcs" "assert-committed"]
+                                          ["bump-release"]
+                                          ["modules" "bump-release"]
+                                          ["vcs" "commit"]
+                                          ["vcs" "tag"]
+                                          ["modules" "deploy"]
+                                          ["change" "version" "leiningen.release/bump-version" "patch"]
+                                          ["modules" "change" "version" "leiningen.release/bump-version" "patch"]
+                                          ["vcs" "commit"]
+                                          ["vcs" "push"]]}}
+  :modules {:subprocess nil
+            :dirs       ["lein-finagle-clojure" "core" "thrift" "http"]
+            :versions   {org.clojure/clojure    "1.10.0"
+                         finagle-clojure        :version}}
   :codox {:sources                   ["core/src" "thrift/src" "http/src"]
           :defaults                  {:doc/format :markdown}
           :output-dir                "doc/codox"

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -1,17 +1,21 @@
-(defproject finagle-clojure/thrift "0.8.0-NUBANK"
+(def lein-finagle-clojure-version
+  (:version (leiningen.core.project/read "./project.clj")))
+
+(defproject finagle-clojure/thrift "0.8.0-SNAPSHOT"
   :description "A light wrapper around finagle-thrift for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :scm {:name "git" :url "https://github.com/nubank/finagle-clojure"}
   :plugins [[s3-wagon-private "1.3.1"]
-            [lein-midje "3.2.1"]]
-  :profiles {:dev {:dependencies   [[org.clojure/clojure "1.10.0"]
-                                     [midje "1.9.9" :exclusions [org.clojure/clojure]]
-                                     [br.com.nubank/tls-extensions "7.2.0"]]
-                    :plugins        [[lein-finagle-clojure "0.8.0-SNAPSHOT"]]
-                    :resource-paths ["test/resources"]
-                    :test-paths     ["test/clj/"]}}
+            [lein-midje "3.2.1"]
+            [lein-modules "0.3.11"]]
+  :profiles {:dev   {:dependencies   [[org.clojure/clojure "1.10.0"]
+                                      [midje "1.9.9" :exclusions [org.clojure/clojure]]
+                                      [br.com.nubank/tls-extensions "7.2.0"]]
+                     :resource-paths ["test/resources"]
+                     :test-paths     ["test/clj/"]}
+             :midje {:plugins [[lein-finagle-clojure ~lein-finagle-clojure-version]]}}
   :finagle-clojure {:thrift-source-path "test/resources" :thrift-output-path "test/java"}
   :java-source-paths ["test/java"]
   :jar-exclusions [#"test"]
@@ -23,7 +27,7 @@
   ;; but also to require fewer dependencies in projects that use thrift.
   ;; this is akin to Finagle itself, where depending on finagle-thrift
   ;; pulls in finagle-core as well.
-  :dependencies [[finagle-clojure/core "0.8.0-NUBANK"]
+  :dependencies [[finagle-clojure/core :version]
                  [com.twitter/finagle-thrift_2.11 "19.12.0"]
                  [org.apache.thrift/libthrift "0.10.0"]
                  [org.apache.tomcat/tomcat-jni "8.5.0"]])


### PR DESCRIPTION
In this PR I added lein-modules so it should be easier to deploy without making a custom pipeline for finagle-clojure project in gocd.