### PR TITLE
Rollbacking thrift due to breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.10.1
+- Rollbacking thrift bump until we generate a new release with a compatible code with thrift `0.13.0`
+
 ## 0.10.0
 We are bumping `org.apache.thrift/libthrift` on `finagle-cloure/thrift` due to security issues with the current version.
 The nearest version without known vulnerabilities is `0.13.0`.

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -26,5 +26,5 @@
   ;; pulls in finagle-core as well.
   :dependencies [[finagle-clojure/core "0.9.0-SNAPSHOT"]
                  [com.twitter/finagle-thrift_2.11 "20.8.1"]
-                 [org.apache.thrift/libthrift "0.13.0"]
+                 [org.apache.thrift/libthrift "0.10.0"]
                  [org.apache.tomcat/tomcat-jni "8.5.0"]])


### PR DESCRIPTION
## Changelog:
- Rollbacking thrift bump until we generate a new release with a compatible code with thrift `0.13.0`