### PR TITLE
Version 1.0.1-SNAPSHOT

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/core "1.0.0"
+(defproject finagle-clojure/core "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle & Twitter Util for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/http/project.clj
+++ b/http/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/http "1.0.0"
+(defproject finagle-clojure/http "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle HTTP for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -11,6 +11,6 @@
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]]}}
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
-  :dependencies [[finagle-clojure/core "1.0.0"]
+  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]])

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-finagle-clojure "1.0.0"
+(defproject lein-finagle-clojure "1.0.1-SNAPSHOT"
   :description "A lein plugin for working with finagle-clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure "1.0.0"
+(defproject finagle-clojure "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/thrift "1.0.0"
+(defproject finagle-clojure/thrift "1.0.1-SNAPSHOT"
   :description "A light wrapper around finagle-thrift for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -26,7 +26,7 @@
   ;; but also to require fewer dependencies in projects that use thrift.
   ;; this is akin to Finagle itself, where depending on finagle-thrift
   ;; pulls in finagle-core as well.
-  :dependencies [[finagle-clojure/core "1.0.0"]
+  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-thrift_2.13 "24.2.0"]
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version


### PR DESCRIPTION
## Changelog:
- Bump all modules to `1.0.1-SNAPSHOT`, starting the next development iteration after the [1.0.0 release](https://github.com/nubank/finagle-clojure/releases/tag/1.0.0).
- Keep the thrift `:midje` profile pinned to the released `lein-finagle-clojure "1.0.0"` (now resolvable from CodeArtifact), instead of the historical unpublished-SNAPSHOT reference.

Completes the manual release flow: 1.0.0 was built from the master merge commit (d694ace), published to CodeArtifact (`finagle-clojure/{core,http,thrift}` + `lein-finagle-clojure`), tagged, and released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)