### PR TITLE
fix(deps): pin patched versions of vulnerable Finagle/scrooge transitives

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -7,10 +7,18 @@
   :plugins [[s3-wagon-private "1.3.1"]
             [lein-midje "3.2"]
             [lein-modules "0.3.11"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.2"]
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]
                                   [criterium "0.4.4"]]}}
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
+  ;; the explicit scala/jackson pins below override vulnerable transitive
+  ;; versions pulled by finagle 24.2.0 (the last Finagle release ever published);
+  ;; jackson artifacts must stay aligned on the same version
   :dependencies [[com.twitter/finagle-core_2.13 "24.2.0"]
-                 [org.clojure/algo.monads "0.1.6"]])
+                 [org.clojure/algo.monads "0.1.6"]
+                 [org.scala-lang/scala-library "2.13.16"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.8"]])

--- a/http/project.clj
+++ b/http/project.clj
@@ -7,10 +7,36 @@
   :plugins [[s3-wagon-private "1.3.1"]
             [lein-midje "3.2"]
             [lein-modules "0.3.11"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.2"]
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]]}}
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
+  ;; the netty pins below override the vulnerable 4.1.100.Final pulled by
+  ;; finagle 24.2.0 (the last Finagle release ever published); all netty
+  ;; artifacts must stay aligned on the same version, including the
+  ;; classified native-epoll jars (conflict resolution is per classifier)
   :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
-                 [com.twitter/finagle-stats_2.13 "24.2.0"]])
+                 [com.twitter/finagle-stats_2.13 "24.2.0"]
+                 [org.scala-lang/scala-library "2.13.16"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.8"]
+                 [io.netty/netty-buffer "4.1.135.Final"]
+                 [io.netty/netty-codec "4.1.135.Final"]
+                 [io.netty/netty-codec-dns "4.1.135.Final"]
+                 [io.netty/netty-codec-http "4.1.135.Final"]
+                 [io.netty/netty-codec-http2 "4.1.135.Final"]
+                 [io.netty/netty-codec-socks "4.1.135.Final"]
+                 [io.netty/netty-common "4.1.135.Final"]
+                 [io.netty/netty-handler "4.1.135.Final"]
+                 [io.netty/netty-handler-proxy "4.1.135.Final"]
+                 [io.netty/netty-resolver "4.1.135.Final"]
+                 [io.netty/netty-resolver-dns "4.1.135.Final"]
+                 [io.netty/netty-transport "4.1.135.Final"]
+                 [io.netty/netty-transport-classes-epoll "4.1.135.Final"]
+                 [io.netty/netty-transport-native-unix-common "4.1.135.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final" :classifier "linux-x86_64"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final" :classifier "linux-aarch_64"]])

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -11,6 +11,19 @@
                  ["sonatype" "https://oss.sonatype.org/content/groups/public/"]
                  ["twitter" {:url "https://maven.twttr.com/" :checksum :warn}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
+  ;; the pins below override vulnerable transitives of scrooge 24.2.0
+  ;; (the last scrooge release ever published); libthrift is capped at
+  ;; 0.12.0 for the same scrooge codegen compatibility reason documented
+  ;; in thrift/project.clj
   :dependencies [[com.twitter/scrooge-generator_2.13 "24.2.0"]
-                 [com.twitter/scrooge-linter_2.13 "24.2.0"]]
+                 [com.twitter/scrooge-linter_2.13 "24.2.0"]
+                 [org.apache.thrift/libthrift "0.12.0"]
+                 [org.scala-lang/scala-library "2.13.16"]
+                 [org.codehaus.plexus/plexus-utils "3.6.1"]
+                 [com.google.guava/guava "32.0.1-jre"]
+                 [org.apache.httpcomponents/httpclient "4.5.14"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.8"]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                                           ["vcs" "push"]]}}
   :modules {:subprocess nil
             :dirs       ["lein-finagle-clojure" "core" "thrift" "http"]
-            :versions   {org.clojure/clojure    "1.10.0"
+            :versions   {org.clojure/clojure    "1.11.2"
                          finagle-clojure        :version}}
   :codox {:sources                   ["core/src" "thrift/src" "http/src"]
           :defaults                  {:doc/format :markdown}

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -7,11 +7,17 @@
   :plugins [[s3-wagon-private "1.3.1"]
             [lein-midje "3.2.1"]
             [lein-modules "0.3.11"]]
-  :profiles {:dev   {:dependencies   [[org.clojure/clojure "1.10.0"]
+  :profiles {:dev   {:dependencies   [[org.clojure/clojure "1.11.2"]
                                       [midje "1.9.9" :exclusions [org.clojure/clojure]]
                                       [br.com.nubank/tls-extensions "7.2.0"]
                                       ;; tls-extensions uses javax.xml.bind, gone from the JDK since Java 11
-                                      [javax.xml.bind/jaxb-api "2.3.1"]]
+                                      [javax.xml.bind/jaxb-api "2.3.1"]
+                                      ;; CVE pins for vulnerable transitives of tls-extensions;
+                                      ;; aws-java-sdk-core is pinned alongside s3 so the two stay aligned
+                                      [com.google.code.gson/gson "2.10.1"]
+                                      [com.google.guava/guava "32.0.1-jre"]
+                                      [com.amazonaws/aws-java-sdk-s3 "1.12.261"]
+                                      [com.amazonaws/aws-java-sdk-core "1.12.261"]]
                      :resource-paths ["test/resources"]
                      :test-paths     ["test/clj/"]}
              :midje {:plugins [[lein-finagle-clojure "1.0.0"]]}}
@@ -26,9 +32,36 @@
   ;; but also to require fewer dependencies in projects that use thrift.
   ;; this is akin to Finagle itself, where depending on finagle-thrift
   ;; pulls in finagle-core as well.
+  ;; the netty pins below override the vulnerable 4.1.100.Final pulled by
+  ;; finagle 24.2.0 (the last Finagle release ever published); all netty
+  ;; artifacts must stay aligned on the same version, including the
+  ;; classified native-epoll jars (conflict resolution is per classifier)
   :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-thrift_2.13 "24.2.0"]
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version
                  [org.apache.thrift/libthrift "0.12.0"]
-                 [org.apache.tomcat/tomcat-jni "8.5.100"]])
+                 ;; httpclient is a vulnerable transitive of libthrift
+                 [org.apache.httpcomponents/httpclient "4.5.14"]
+                 [org.apache.tomcat/tomcat-jni "8.5.100"]
+                 [org.scala-lang/scala-library "2.13.16"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.8"]
+                 [io.netty/netty-buffer "4.1.135.Final"]
+                 [io.netty/netty-codec "4.1.135.Final"]
+                 [io.netty/netty-codec-dns "4.1.135.Final"]
+                 [io.netty/netty-codec-http "4.1.135.Final"]
+                 [io.netty/netty-codec-socks "4.1.135.Final"]
+                 [io.netty/netty-common "4.1.135.Final"]
+                 [io.netty/netty-handler "4.1.135.Final"]
+                 [io.netty/netty-handler-proxy "4.1.135.Final"]
+                 [io.netty/netty-resolver "4.1.135.Final"]
+                 [io.netty/netty-resolver-dns "4.1.135.Final"]
+                 [io.netty/netty-transport "4.1.135.Final"]
+                 [io.netty/netty-transport-classes-epoll "4.1.135.Final"]
+                 [io.netty/netty-transport-native-unix-common "4.1.135.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final" :classifier "linux-x86_64"]
+                 [io.netty/netty-transport-native-epoll "4.1.135.Final" :classifier "linux-aarch_64"]])


### PR DESCRIPTION
## Summary

Resolves the bulk (~100) of the [130 open Dependabot alerts](https://github.com/nubank/finagle-clojure/security/dependabot). Finagle **24.2.0 is the last release ever published**, so the vulnerable transitives it pulls can't be fixed by a framework bump — this PR overrides them with explicit pins, which Leiningen resolves over transitives (and which propagate to consumers' dependency trees via the published POMs).

| Pin | From → To | Alerts | Where |
|---|---|---|---|
| `io.netty:*` (full aligned set, incl. classified `native-epoll` jars) | 4.1.100.Final → **4.1.135.Final** | 56 | http, thrift |
| `jackson-{core,databind,annotations,module-scala}` (aligned) | 2.14.3 → **2.18.8** | 24 | all modules |
| `scala-library` | 2.13.6 → **2.13.16** | 4 (critical) | all modules |
| `org.clojure/clojure` (dev/test) | 1.10.0 → **1.11.2** | 3 | core, http, thrift |
| `plexus-utils` | 1.5.4 → **3.6.1** | 4 (1 critical) | lein plugin |
| `guava` → 32.0.1-jre, `httpclient` → 4.5.14, `gson` → 2.10.1, `aws-java-sdk-s3/core` → 1.12.261 | various | ~13 | thrift (dev), lein plugin |
| `libthrift` | 0.10.0 → **0.12.0** | partial | lein plugin |

### Deliberately not bumped
- **snakeyaml** (21 alerts): 2.x broke the 1.x API — needs separate validation of whichever transitive consumes it.
- **libthrift beyond 0.12.0** (7 alerts): scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+ changed it to `void` (already documented in `thrift/project.clj`). Unfixable without a scrooge change; candidates for alert dismissal.

### Validation
- `lein classpath` in all 4 modules resolves exactly the patched versions (netty/jackson kept as aligned sets — mixing versions within those families breaks at runtime; native-epoll classified jars pinned explicitly since Maven conflict resolution is per-classifier).
- Midje suites pass: **core 114, http 34, thrift 13 checks** — the http suite exercises the real Netty 4.1.135 stack (`Netty4InetResolver` loads).
- `lein install` succeeds for the plugin module.

After merge, a release needs to be cut so consumers pick up the pins — merging only fixes this repo's own dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)