### PR TITLE
fix(deps): pin snakeyaml 1.33 to clear pre-1.32 DoS CVEs

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -18,6 +18,9 @@
   :dependencies [[com.twitter/finagle-core_2.13 "24.2.0"]
                  [org.clojure/algo.monads "0.1.6"]
                  [org.scala-lang/scala-library "2.13.16"]
+                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
+                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
+                 [org.yaml/snakeyaml "1.33"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]

--- a/http/project.clj
+++ b/http/project.clj
@@ -19,6 +19,9 @@
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]
                  [org.scala-lang/scala-library "2.13.16"]
+                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
+                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
+                 [org.yaml/snakeyaml "1.33"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -45,6 +45,9 @@
                  [org.apache.httpcomponents/httpclient "4.5.14"]
                  [org.apache.tomcat/tomcat-jni "8.5.100"]
                  [org.scala-lang/scala-library "2.13.16"]
+                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
+                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
+                 [org.yaml/snakeyaml "1.33"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]


### PR DESCRIPTION
## Summary

Follow-up to #21. Pins `org.yaml/snakeyaml` to **1.33** in `core`, `http`, and `thrift` (it arrives transitively at 1.28 via `com.twitter/util-security` from Finagle 24.2.0, the last Finagle release ever published).

1.33 stays on the 1.x line — no API break — and clears **20 of the 21 open snakeyaml alerts** (the stack-overflow/OOB-write DoS CVEs fixed in 1.31/1.32, e.g. CVE-2022-38752, CVE-2022-41854, CVE-2022-25857).

**Not covered:** CVE-2022-1471 (SnakeYaml Constructor RCE) is fixed only in snakeyaml 2.x, which broke the 1.x API. That one alert stays open until a 2.x migration is validated against util-security's usage — or dismissed, since snakeyaml here only parses local operator-authored config YAML, never untrusted input.

## Validation

Midje suites pass on the pinned resolution: **core 114, http 34, thrift 13 checks**. `lein classpath` confirms all three modules resolve snakeyaml 1.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)