### PR TITLE
fix(deps): snakeyaml 2.4 (CVE-2022-1471 RCE) and aws-sdk 1.12.797 (removes ion-java)

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -18,9 +18,9 @@
   :dependencies [[com.twitter/finagle-core_2.13 "24.2.0"]
                  [org.clojure/algo.monads "0.1.6"]
                  [org.scala-lang/scala-library "2.13.16"]
-                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
-                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
-                 [org.yaml/snakeyaml "1.33"]
+                 ;; snakeyaml 2.x clears CVE-2022-1471 (RCE); util-security is exercised
+                 ;; against it by the midje suites
+                 [org.yaml/snakeyaml "2.4"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]

--- a/http/project.clj
+++ b/http/project.clj
@@ -19,9 +19,9 @@
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]
                  [org.scala-lang/scala-library "2.13.16"]
-                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
-                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
-                 [org.yaml/snakeyaml "1.33"]
+                 ;; snakeyaml 2.x clears CVE-2022-1471 (RCE); util-security is exercised
+                 ;; against it by the midje suites
+                 [org.yaml/snakeyaml "2.4"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -16,8 +16,8 @@
                                       ;; aws-java-sdk-core is pinned alongside s3 so the two stay aligned
                                       [com.google.code.gson/gson "2.10.1"]
                                       [com.google.guava/guava "32.0.1-jre"]
-                                      [com.amazonaws/aws-java-sdk-s3 "1.12.261"]
-                                      [com.amazonaws/aws-java-sdk-core "1.12.261"]]
+                                      [com.amazonaws/aws-java-sdk-s3 "1.12.797"]
+                                      [com.amazonaws/aws-java-sdk-core "1.12.797"]]
                      :resource-paths ["test/resources"]
                      :test-paths     ["test/clj/"]}
              :midje {:plugins [[lein-finagle-clojure "1.0.0"]]}}
@@ -45,9 +45,9 @@
                  [org.apache.httpcomponents/httpclient "4.5.14"]
                  [org.apache.tomcat/tomcat-jni "8.5.100"]
                  [org.scala-lang/scala-library "2.13.16"]
-                 ;; snakeyaml 1.33 clears the <1.32 DoS CVEs without the 2.x API break;
-                 ;; CVE-2022-1471 (fixed only in 2.x) remains open until the 2.x migration
-                 [org.yaml/snakeyaml "1.33"]
+                 ;; snakeyaml 2.x clears CVE-2022-1471 (RCE); util-security is exercised
+                 ;; against it by the midje suites
+                 [org.yaml/snakeyaml "2.4"]
                  [com.fasterxml.jackson.core/jackson-core "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-databind "2.18.8"]
                  [com.fasterxml.jackson.core/jackson-annotations "2.18.8"]


### PR DESCRIPTION
## Summary

Clears the last **fixable** Dependabot alerts (follow-up to #21/#22):

| Change | Fixes | Why |
|---|---|---|
| `snakeyaml` 1.33 → **2.4** (core, http, thrift) | #113, #149, #164 — CVE-2022-1471 Constructor RCE (high) | Fixed only in the 2.x line. `util-security`'s YAML usage survives the 2.x API change — validated by the test suites. |
| `aws-java-sdk-s3/core` 1.12.261 → **1.12.797** (thrift dev profile) | #170 — ion-java CVE-2024-21634 (high) | 1.12.261 pulls `software.amazon.ion:ion-java`, whose coordinates are abandoned (no patched release exists — the fix lives under `com.amazon.ion`). 1.12.797 dropped ion-java entirely, so the vulnerable artifact leaves the tree. |

## Validation

- Midje suites pass: **core 114, http 34, thrift 13 checks**.
- The thrift suite performs the real S3 keystore download via tls-extensions, exercising aws-sdk 1.12.797 end-to-end.
- `lein classpath` confirms snakeyaml 2.4 resolves in all three modules and ion-java is gone from thrift.

After this merges, every remaining open alert is a justified dismissal (jackson CVE-2026-54515 with no patched release; libthrift capped at 0.12.0 by scrooge codegen compatibility, with the vulnerable TSSLTransport path unused since finagle-thrift does TLS via Netty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)