### PR TITLE
Pin patched jackson 2.18.9 stack (GHSA-5jmj-h7xm-6q6v)

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/core "1.0.0"
+(defproject finagle-clojure/core "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle & Twitter Util for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/core/project.clj
+++ b/core/project.clj
@@ -13,4 +13,10 @@
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
   :dependencies [[com.twitter/finagle-core_2.13 "24.2.0"]
+                 ;; full jackson 2.18.9 stack (GHSA-5jmj-h7xm-6q6v); Finagle bundles a vulnerable 2.14.x,
+                 ;; and jackson-module-scala enforces databind version match, so all four move together
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.9"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.9" :exclusions [com.google.guava/guava]]
                  [org.clojure/algo.monads "0.1.6"]])

--- a/http/project.clj
+++ b/http/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/http "1.0.0"
+(defproject finagle-clojure/http "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle HTTP for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -11,6 +11,6 @@
                                   [midje "1.9.9" :exclusions [org.clojure/clojure]]]}}
   :repositories [["nu-maven" {:url "s3p://nu-maven/releases/"}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
-  :dependencies [[finagle-clojure/core "1.0.0"]
+  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]])

--- a/http/project.clj
+++ b/http/project.clj
@@ -13,4 +13,9 @@
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
   :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
-                 [com.twitter/finagle-stats_2.13 "24.2.0"]])
+                 [com.twitter/finagle-stats_2.13 "24.2.0"]
+                 ;; full jackson 2.18.9 stack (GHSA-5jmj-h7xm-6q6v); module-scala must match databind
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.9"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.9" :exclusions [com.google.guava/guava]]])

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-finagle-clojure "1.0.0"
+(defproject lein-finagle-clojure "1.0.1-SNAPSHOT"
   :description "A lein plugin for working with finagle-clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -12,5 +12,11 @@
                  ["twitter" {:url "https://maven.twttr.com/" :checksum :warn}]]
   :deploy-repositories [["releases" {:url "s3p://nu-maven/releases/" :no-auth true}]]
   :dependencies [[com.twitter/scrooge-generator_2.13 "24.2.0"]
-                 [com.twitter/scrooge-linter_2.13 "24.2.0"]]
+                 [com.twitter/scrooge-linter_2.13 "24.2.0"]
+                 ;; full jackson 2.18.9 stack (GHSA-5jmj-h7xm-6q6v); scrooge bundles a vulnerable 2.14.x,
+                 ;; and jackson-module-scala enforces databind version match, so all four move together
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.9"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.9" :exclusions [com.google.guava/guava org.scala-lang.modules/scala-collection-compat_3]]]
   :eval-in-leiningen true)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure "1.0.0"
+(defproject finagle-clojure "1.0.1-SNAPSHOT"
   :description "A light wrapper around Finagle for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/thrift "1.0.0"
+(defproject finagle-clojure/thrift "1.0.1-SNAPSHOT"
   :description "A light wrapper around finagle-thrift for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -26,7 +26,7 @@
   ;; but also to require fewer dependencies in projects that use thrift.
   ;; this is akin to Finagle itself, where depending on finagle-thrift
   ;; pulls in finagle-core as well.
-  :dependencies [[finagle-clojure/core "1.0.0"]
+  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
                  [com.twitter/finagle-thrift_2.13 "24.2.0"]
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -31,4 +31,10 @@
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version
                  [org.apache.thrift/libthrift "0.12.0"]
+                 ;; full jackson 2.18.9 stack (GHSA-5jmj-h7xm-6q6v); Finagle bundles a vulnerable 2.14.x,
+                 ;; and jackson-module-scala enforces databind version match, so all four move together
+                 [com.fasterxml.jackson.core/jackson-databind "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-core "2.18.9"]
+                 [com.fasterxml.jackson.core/jackson-annotations "2.18.9"]
+                 [com.fasterxml.jackson.module/jackson-module-scala_2.13 "2.18.9" :exclusions [com.google.guava/guava]]
                  [org.apache.tomcat/tomcat-jni "8.5.100"]])


### PR DESCRIPTION
## Changelog:
- Pin the full jackson `2.18.9` stack (`jackson-databind`, `jackson-core`, `jackson-annotations`, `jackson-module-scala_2.13`) across `core`, `http`, `thrift`, and `lein-finagle-clojure`.

### Why the whole stack, not just databind
Dependabot flags `jackson-databind` (GHSA-5jmj-h7xm-6q6v, medium — `@JsonIgnoreProperties` case-insensitive deserialization bypass); the fix is `>= 2.18.9`. Finagle 24.2.0 and scrooge bundle jackson `2.14.3` transitively.

A lone `jackson-databind` pin does **not** work: `jackson-module-scala 2.14.3` enforces a matching databind version at runtime (`>= 2.14.0, < 2.15.0`), so pinning only databind to 2.18.9 crashes Finagle's `Http$Server` static init with `Scala module 2.14.3 requires Jackson Databind version >= 2.14.0 and < 2.15.0`. All four artifacts therefore move to 2.18.9 together.

### Testing
`lein midje` — core **114 checks**, http **34 checks**, both green. This exercises the `Http$Server$`/module-scala init path that the databind-only pin breaks. (thrift's TLS test additionally needs a live keystore fetch from S3; its jackson resolution is verified via `lein deps :tree` and it compiles clean.)

### Related
- Closes Dependabot alerts #105 (core), #130 (http), #156 (lein).
- The two `libthrift` alerts (#99, #89) are dismissed separately as "not used": finagle-clojure does TLS via Finagle's Netty transport, not libthrift's vulnerable `TSSLTransportFactory`, and libthrift is codegen-pinned to 0.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)