### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.1 (2026-07-14)
+Dependency-security patch release — CVE-clearing pins over Finagle 24.2.0's frozen transitive set. No API or behavior changes.
+- **netty** pinned to `4.1.135.Final` across the aligned set (clears 56 alerts).
+- **jackson** core/databind/annotations/module-scala_2.13 aligned at `2.18.9` (GHSA-5jmj-h7xm-6q6v). All four move together because `jackson-module-scala` enforces a matching `jackson-databind` version at runtime.
+- **scala-library** `2.13.16` (critical alerts).
+- **snakeyaml** `2.4` (CVE-2022-1471 RCE).
+- **aws-java-sdk-s3/core** `1.12.797` (drops vulnerable transitive `ion-java`).
+- **plexus-utils** `3.6.1`, **guava** `32.0.1-jre`, **httpclient** `4.5.14`, **gson** `2.10.1`.
+- `libthrift` remains `0.12.0`: scrooge `24.2.0` codegen requires the pre-`0.13` `TProcessor.process` signature, so the patched `0.23.0` is not adoptable (vulnerable TLS transport is unused — finagle-clojure does TLS via Finagle's Netty transport).
+
 ## 1.0.0 (2026-07-03)
 - Bump Finagle and scrooge to `24.2.0` (the final Finagle release) and move the built modules (`core`, `http`, `thrift`, `lein-finagle-clojure`) to Scala 2.13 artifacts. `finagle-clojure-template` is not part of the build and remains stale (it predates the Nubank fork).
 - **Breaking**: remove `finagle-clojure.builder.server` and `finagle-clojure.builder.client`. Finagle removed the underlying `ServerBuilder` API in `21.8.0`. Use the stack pattern instead (`finagle-clojure.http.server`/`finagle-clojure.http.client`); `common-finagle >= 11.38.0` already does.

--- a/core/project.clj
+++ b/core/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/core "1.0.1-SNAPSHOT"
+(defproject finagle-clojure/core "1.0.1"
   :description "A light wrapper around Finagle & Twitter Util for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/http/project.clj
+++ b/http/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/http "1.0.1-SNAPSHOT"
+(defproject finagle-clojure/http "1.0.1"
   :description "A light wrapper around Finagle HTTP for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -15,7 +15,7 @@
   ;; finagle 24.2.0 (the last Finagle release ever published); all netty
   ;; artifacts must stay aligned on the same version, including the
   ;; classified native-epoll jars (conflict resolution is per classifier)
-  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
+  :dependencies [[finagle-clojure/core "1.0.1"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]
                  [org.scala-lang/scala-library "2.13.16"]

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-finagle-clojure "1.0.1-SNAPSHOT"
+(defproject lein-finagle-clojure "1.0.1"
   :description "A lein plugin for working with finagle-clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure "1.0.1-SNAPSHOT"
+(defproject finagle-clojure "1.0.1"
   :description "A light wrapper around Finagle for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/thrift "1.0.1-SNAPSHOT"
+(defproject finagle-clojure/thrift "1.0.1"
   :description "A light wrapper around finagle-thrift for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -36,7 +36,7 @@
   ;; finagle 24.2.0 (the last Finagle release ever published); all netty
   ;; artifacts must stay aligned on the same version, including the
   ;; classified native-epoll jars (conflict resolution is per classifier)
-  :dependencies [[finagle-clojure/core "1.0.1-SNAPSHOT"]
+  :dependencies [[finagle-clojure/core "1.0.1"]
                  [com.twitter/finagle-thrift_2.13 "24.2.0"]
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version


### PR DESCRIPTION
## Changelog:
- Set the release version `1.0.1` across all modules. **This PR's merge commit is the 1.0.1 release commit** (manual release flow — Bookworm doesn't operate on this public repo).

### What's in 1.0.1
A dependency-security patch release. Every change since 1.0.0 (#21–#24) is a CVE-clearing transitive pin over Finagle 24.2.0's frozen dependency set — **no API or behavior changes**:
- netty `4.1.135.Final`, jackson stack `2.18.9`, scala-library `2.13.16`, snakeyaml `2.4`, aws-sdk `1.12.797` (drops ion-java), plus plexus-utils / guava / httpclient / gson pins.
- `libthrift` stays `0.12.0` (scrooge 24.2.0 codegen constraint).

thrift's `:midje` plugin ref is intentionally held at the released `1.0.0` so this build resolves a published plugin; it moves to `1.0.1` in the follow-up next-dev PR once the 1.0.1 plugin is published.

### Testing
`lein midje` all green at the release coordinates: core **114**, http **34**, thrift **13**.

### Post-merge (manual release)
Build from master → publish core/http/thrift/lein-finagle-clojure `1.0.1` to CodeArtifact → verify by resolution → tag `1.0.1` → next-dev `1.0.2-SNAPSHOT` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)