### PR TITLE
Version 1.0.2-SNAPSHOT

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/core "1.0.1"
+(defproject finagle-clojure/core "1.0.2-SNAPSHOT"
   :description "A light wrapper around Finagle & Twitter Util for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/http/project.clj
+++ b/http/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/http "1.0.1"
+(defproject finagle-clojure/http "1.0.2-SNAPSHOT"
   :description "A light wrapper around Finagle HTTP for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -15,7 +15,7 @@
   ;; finagle 24.2.0 (the last Finagle release ever published); all netty
   ;; artifacts must stay aligned on the same version, including the
   ;; classified native-epoll jars (conflict resolution is per classifier)
-  :dependencies [[finagle-clojure/core "1.0.1"]
+  :dependencies [[finagle-clojure/core "1.0.2-SNAPSHOT"]
                  [com.twitter/finagle-http_2.13 "24.2.0"]
                  [com.twitter/finagle-stats_2.13 "24.2.0"]
                  [org.scala-lang/scala-library "2.13.16"]

--- a/lein-finagle-clojure/project.clj
+++ b/lein-finagle-clojure/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-finagle-clojure "1.0.1"
+(defproject lein-finagle-clojure "1.0.2-SNAPSHOT"
   :description "A lein plugin for working with finagle-clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure "1.0.1"
+(defproject finagle-clojure "1.0.2-SNAPSHOT"
   :description "A light wrapper around Finagle for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"

--- a/thrift/project.clj
+++ b/thrift/project.clj
@@ -1,4 +1,4 @@
-(defproject finagle-clojure/thrift "1.0.1"
+(defproject finagle-clojure/thrift "1.0.2-SNAPSHOT"
   :description "A light wrapper around finagle-thrift for Clojure"
   :url "https://github.com/twitter/finagle-clojure"
   :license {:name "Apache License, Version 2.0"
@@ -20,7 +20,7 @@
                                       [com.amazonaws/aws-java-sdk-core "1.12.797"]]
                      :resource-paths ["test/resources"]
                      :test-paths     ["test/clj/"]}
-             :midje {:plugins [[lein-finagle-clojure "1.0.0"]]}}
+             :midje {:plugins [[lein-finagle-clojure "1.0.1"]]}}
   :finagle-clojure {:thrift-source-path "test/resources" :thrift-output-path "test/java"}
   :java-source-paths ["test/java"]
   :jar-exclusions [#"test"]
@@ -36,7 +36,7 @@
   ;; finagle 24.2.0 (the last Finagle release ever published); all netty
   ;; artifacts must stay aligned on the same version, including the
   ;; classified native-epoll jars (conflict resolution is per classifier)
-  :dependencies [[finagle-clojure/core "1.0.1"]
+  :dependencies [[finagle-clojure/core "1.0.2-SNAPSHOT"]
                  [com.twitter/finagle-thrift_2.13 "24.2.0"]
                  ;; scrooge 24.2.0 generates `boolean TProcessor.process`; libthrift 0.13+
                  ;; changed it to void, so 0.12.0 is the newest compatible version


### PR DESCRIPTION
## Changelog:
- Bump all modules to `1.0.2-SNAPSHOT`, starting the next development iteration after the [1.0.1 release](https://github.com/nubank/finagle-clojure/releases/tag/1.0.1).
- Point thrift's `:midje` plugin ref at the now-published `lein-finagle-clojure "1.0.1"` (was `1.0.0`), so the thrift build/codegen runs against the patched jackson stack — closing the build-time gap noted in #24.

Completes the 1.0.1 manual release: built from the master merge commit (`5aed25a`), all four artifacts (`finagle-clojure/{core,http,thrift}` + `lein-finagle-clojure`) published to CodeArtifact `private-maven` and verified at `1.0.1` via `nu codeartifact latest`, tagged `1.0.1`, GitHub release created.

Note: `maven.cicd.nubank.world` proxy resolution of freshly-published versions lags briefly (copy-on-read); the authoritative check is `nu codeartifact latest maven <pkg> <namespace>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)